### PR TITLE
test: disable animations to increase test reliability

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/ankisrskai/AnkiSrsKaiAddonTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/ankisrskai/AnkiSrsKaiAddonTest.kt
@@ -15,6 +15,7 @@ import com.ichi2.anki.ankisrskai.AnkiSrsKaiTestUtils.Companion.clickShowAnswerAn
 import com.ichi2.anki.ankisrskai.AnkiSrsKaiTestUtils.Companion.clickShowAnswerAndAnswerHard
 import com.ichi2.anki.ankisrskai.AnkiSrsKaiTestUtils.Companion.closeBackupCollectionDialogIfExists
 import com.ichi2.anki.ankisrskai.AnkiSrsKaiTestUtils.Companion.closeGetStartedScreenIfExists
+import com.ichi2.anki.ankisrskai.AnkiSrsKaiTestUtils.Companion.disableAnimations
 import com.ichi2.anki.ankisrskai.AnkiSrsKaiTestUtils.Companion.hasCardType
 import com.ichi2.anki.ankisrskai.AnkiSrsKaiTestUtils.Companion.hasCustomData
 import com.ichi2.anki.ankisrskai.AnkiSrsKaiTestUtils.Companion.hasDesiredRetention
@@ -63,6 +64,7 @@ class AnkiSrsKaiAddonTest : InstrumentedTest() {
 
     @Before
     fun setup() {
+        disableAnimations()
         runBlocking {
             CollectionManager.deleteCollectionDirectory()
         }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/ankisrskai/AnkiSrsKaiIntegrationTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/ankisrskai/AnkiSrsKaiIntegrationTest.kt
@@ -15,6 +15,7 @@ import com.ichi2.anki.ankisrskai.AnkiSrsKaiTestUtils.Companion.clickShowAnswerAn
 import com.ichi2.anki.ankisrskai.AnkiSrsKaiTestUtils.Companion.clickShowAnswerAndAnswerHard
 import com.ichi2.anki.ankisrskai.AnkiSrsKaiTestUtils.Companion.closeBackupCollectionDialogIfExists
 import com.ichi2.anki.ankisrskai.AnkiSrsKaiTestUtils.Companion.closeGetStartedScreenIfExists
+import com.ichi2.anki.ankisrskai.AnkiSrsKaiTestUtils.Companion.disableAnimations
 import com.ichi2.anki.ankisrskai.AnkiSrsKaiTestUtils.Companion.hasCardType
 import com.ichi2.anki.ankisrskai.AnkiSrsKaiTestUtils.Companion.hasCustomData
 import com.ichi2.anki.ankisrskai.AnkiSrsKaiTestUtils.Companion.hasDesiredRetention
@@ -66,6 +67,7 @@ class AnkiSrsKaiIntegrationTest : InstrumentedTest() {
 
     @Before
     fun setup() {
+        disableAnimations()
         runBlocking {
             CollectionManager.deleteCollectionDirectory()
         }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/ankisrskai/AnkiSrsKaiTestUtils.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/ankisrskai/AnkiSrsKaiTestUtils.kt
@@ -1,6 +1,8 @@
 package com.ichi2.anki.ankisrskai
 
+import android.content.Context
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.ViewAssertion
 import androidx.test.espresso.ViewInteraction
@@ -17,6 +19,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import anki.cards.FsrsMemoryState
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.R
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.utils.TimeManager
@@ -27,6 +30,12 @@ import kotlin.test.fail
 
 class AnkiSrsKaiTestUtils private constructor() {
     companion object {
+        fun disableAnimations() {
+            val context = ApplicationProvider.getApplicationContext<Context>()
+            val key = context.getString(R.string.safe_display_key)
+            context.sharedPrefs().edit().putBoolean(key, true).commit()
+        }
+
         fun closeGetStartedScreenIfExists() {
             onView(withId(R.id.get_started))
                 .withFailureHandler { _, _ -> }


### PR DESCRIPTION
In CI, the tests would sometimes fail on the GitHub runners because when clicking on the hamburger icon, the drawer layout would sometimes close immediately.